### PR TITLE
 .eslintignore fix for development on /src folder

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,4 @@
 /tests
-/migrations/
-/seeders/
-/models/index.js
+**/migrations/
+**/seeders/
+**/models/index.js


### PR DESCRIPTION
Contexto, lint reclama de `models/index.js` dentro da pasta `src` sendo que no [vídeo do conteúdo](https://app.betrybe.com/course/back-end/arquitetura-solid-e-orm/orm-interface-da-aplicacao-com-o-banco-de-dados/d0fc385e-b0ce-4b3d-8246-779d5dc13682/conteudos/c9f6fa92-fdf3-4632-bddb-f29f99bb4f59/sequelize-do-zero/352c5468-bfab-4d58-a450-9bd218800d4e?use_case=side_bar) diz que isso é uma boa prática